### PR TITLE
intel: Pick the best ABI based on number of libs, not just priority

### DIFF
--- a/core/jni/Android.mk
+++ b/core/jni/Android.mk
@@ -16,6 +16,10 @@ else
     LOCAL_CFLAGS += -DPACKED=""
 endif
 
+ifeq ($(TARGET_ARCH), x86)
+    LOCAL_CFLAGS += -DPICK_SUPPORTED_ABI_WITH_MAX_LIBS
+endif
+
 ifneq ($(ENABLE_CPUSETS),)
     LOCAL_CFLAGS += -DENABLE_CPUSETS
 endif


### PR DESCRIPTION
The normal package loading will open the APK and find the highest
priority ABI that contains one or more native libraries.

This works well for 64-bit vs. 32-bit but doesn't work very well
for ARM vs. Intel ABIs.  There are many broken apps in the market
which fail to run when installed as x86.

I believe that there are so many apps because an app that doesn't
itself have native x86 libs but imports a 3rd party lib that does
support x86 will end up installin the x86 libs for the support
library which fools the package installer.

As a simple heuristic, pick the ABI that contains the most shared
libraries.  That works around the common case of missing the
app's own shared libraries.

Note: the consequences of picking incorrectly are actually quite
small since the app should still run, although it will run
less efficiently because it is emulated.

Note: if two ABIs have the same number of libs, we pick the higher
priority one as a tie-breaker.

Change-Id: Ie4880810f46875869ce054b3c46acac64b953996
